### PR TITLE
fix: PS2 Wave Underline

### DIFF
--- a/src/components/common/wave-underline.tsx
+++ b/src/components/common/wave-underline.tsx
@@ -7,7 +7,7 @@ export default function WaveUnderline({ children }: WaveUnderlineProps) {
     <span className="relative inline-block">
       {children}
       <span
-        className="absolute top-8 right-0 bottom-0 left-0 -z-10 h-full bg-[url('/wave-underline.svg')] bg-[length:100%_100%] bg-bottom bg-no-repeat"
+        className="absolute top-3 right-0 bottom-0 left-0 -z-10 h-full bg-[url('/wave-underline.svg')] bg-[length:100%_100%] bg-bottom bg-no-repeat sm:top-4 md:top-6 lg:top-8"
         aria-hidden="true"
         role="presentation"
       ></span>


### PR DESCRIPTION
- Updated the top positioning of the wave underline background in the `WaveUnderline` component to enhance its visual alignment across different screen sizes, ensuring a more consistent appearance.